### PR TITLE
add queuing number to html in email

### DIFF
--- a/app/Mail/CreatedAppointmentMail.php
+++ b/app/Mail/CreatedAppointmentMail.php
@@ -24,7 +24,7 @@ class CreatedAppointmentMail extends Mailable
         $this->last_name = $data['last_name'];
         $this->email_address = $data['email_address'];
         $this->schedule_date = $data['schedule_date'];
-        $this->schedule_date = $data['queuing_number'];
+        $this->queuing_number = $data['queuing_number'];
     }
 
     /**

--- a/resources/views/emails/created_appointment.blade.php
+++ b/resources/views/emails/created_appointment.blade.php
@@ -49,7 +49,7 @@
         
         <div class="message">
             <p>Dear {{$first_name}},</p>
-            <p>You have created an appointment scheduled for {{$schedule_date}}.</p>
+            <p>You have created an appointment scheduled for {{$schedule_date}} and your queuing number is {{$queuing_number}}.</p>
             <p>Please make sure to arrive on time and prepare any relevant documents.</p>
         </div>
         


### PR DESCRIPTION
Good day, I have added the queuing number to the HTML content in emails. This update ensures that recipients receive their queuing number directly in the email for easier reference.