### PR TITLE
Add payment_status handling in appointment queries and API

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -273,6 +273,7 @@ class AdminController extends Controller
                 apt.status,
                 apt.otp_used,
                 apt.purpose,
+                apt.payment_status,
                 apt.created_at as request_date,
                 doc_type.price,
                 CASE WHEN apt.updated_at IS NULL THEN '' ELSE apt.updated_at END as release_date,

--- a/database/migrations/2024_10_22_214718_add_payment_status_to_appointments_table.php
+++ b/database/migrations/2024_10_22_214718_add_payment_status_to_appointments_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+    Schema::table('appointments', function (Blueprint $table) {
+        $table->string('payment_status')->default('Unpaid');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropColumn('payment_status');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -77,6 +77,7 @@ Route::middleware(['AuthUser:2-3'])->group(function () {
     Route::post('importExcelResidents', [NewResidentController::class, 'importExcelResidents']);
     Route::post('approveOrRejectAppointment', [AppointmentController::class, 'approveOrRejectAppointment']);
     Route::post('noVerificationRegistration', [UserController::class, 'noVerificationRegistration']); //addbearer
+    Route::post('markAsPaid', [AppointmentController::class, 'markAsPaid']);
     Route::get('viewAdminLogs', [AdminController::class, 'viewAdminLogs']);
 });
     Route::get('testEmail', [UserController::class, 'testEmail']);


### PR DESCRIPTION
- Modified appointment query to fetch and include payment_status
- Ensured payment_status is correctly returned in API responses
- Added logic to handle marking appointments as paid and updating payment_status in the database
- Improved API functionality to support frontend logic for disabling "Paid" button after payment